### PR TITLE
Update request.rb

### DIFF
--- a/lib/restclient/request.rb
+++ b/lib/restclient/request.rb
@@ -56,7 +56,7 @@ module RestClient
       @ssl_client_key = args[:ssl_client_key] || nil
       @ssl_ca_file = args[:ssl_ca_file] || nil
       @ssl_ca_path = args[:ssl_ca_path] || nil
-      @ssl_version = args[:ssl_version] || 'SSLv3'
+      @ssl_version = args[:ssl_version] || 'SSLv23'
       @tf = nil # If you are a raw request, this is your tempfile
       @max_redirects = args[:max_redirects] || 10
       @processed_headers = make_headers headers


### PR DESCRIPTION
Hello,

The poodle security issue has caused the request to fail when it defaults to SSLv3.  I was using this for FB api and it no longer works as SSLv3 is rejected.  By changing line 59 to default value SSLv23 it will default to the newer protocol TLSv1.  
More info: https://github.com/nahi/httpclient/pull/204
Security Issue: http://security.stackexchange.com/questions/70719/ssl3-poodle-vulnerability

Thanks,
Mitch
